### PR TITLE
fixed maple-sim simulation bug

### DIFF
--- a/src/main/java/frc/robot/generated/TunerConstants.java
+++ b/src/main/java/frc/robot/generated/TunerConstants.java
@@ -79,7 +79,7 @@ public class TunerConstants {
   private static final int kPigeonId = 1;
 
   // These are only used for simulation
-  private static final double kSteerInertia = 0.00001;
+  private static final double kSteerInertia = 0.01;
   private static final double kDriveInertia = 0.001;
   // Simulated voltage necessary to overcome friction
   private static final Voltage kSteerFrictionVoltage = Volts.of(0.25);

--- a/src/main/java/frc/robot/subsystems/drive/ModuleIOSim.java
+++ b/src/main/java/frc/robot/subsystems/drive/ModuleIOSim.java
@@ -6,7 +6,6 @@ import static edu.wpi.first.units.Units.RadiansPerSecond;
 import static edu.wpi.first.units.Units.Volts;
 
 import edu.wpi.first.math.controller.PIDController;
-import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
@@ -33,9 +32,7 @@ public class ModuleIOSim implements ModuleIO {
       0.91035; // Same units as TunerConstants: (volt * secs) / rotation
   private static final double DRIVE_KV = 1.0 / Units.rotationsToRadians(1.0 / DRIVE_KV_ROT);
   private static final double TURN_KP = 8.0;
-  private static final double TURN_KD = 0.0;
-  private static final DCMotor DRIVE_GEARBOX = DCMotor.getKrakenX60Foc(1);
-  private static final DCMotor TURN_GEARBOX = DCMotor.getKrakenX60Foc(1);
+  private static final double TURN_KD = 0.2;
 
   private boolean driveClosedLoop = false;
   private boolean turnClosedLoop = false;

--- a/vendordeps/maple-sim.json
+++ b/vendordeps/maple-sim.json
@@ -1,7 +1,7 @@
 {
   "fileName": "maple-sim.json",
   "name": "maplesim",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "frcYear": "2025",
   "uuid": "c39481e8-4a63-4a4c-9df6-48d91e4da37b",
   "mavenUrls": [
@@ -13,7 +13,7 @@
     {
       "groupId": "org.ironmaple",
       "artifactId": "maplesim-java",
-      "version": "0.2.3"
+      "version": "0.2.4"
     },
     {
       "groupId": "org.dyn4j",


### PR DESCRIPTION
The bug mentioned on Discord was due to an incorrect steer inertia setting. This PR addresses and fixes that issue.

Additionally, I've tuned the PID to reduce jittering.

Lastly, I've updated the version to v0.2.4, which we just released.